### PR TITLE
Add a slug option to solve https://github.com/upptime/upptime/issues/456

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ export const generateGraphs = async () => {
   await ensureDir(join(".", "graphs"));
 
   for await (const site of config.sites) {
-    const slug = site.slug ? site.slug: slugify(site.name);
+    const slug = site.slug ? site.slug : slugify(site.name);
     if (!slug) continue;
 
     let uptime = 0;


### PR DESCRIPTION
As https://github.com/upptime/upptime/issues/456, I have modified the "index.js" and add a slug option so if the name of the site only contains the characters that @sindresorhus/slugify doesn't support or the user wants to define their own slugs, the users can just add slug tags in the ".upptimerc.yml". 