### PR TITLE
Remove tiny data point circles from prerendered graphs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,11 @@ export const generateGraphs = async () => {
             ],
           },
           options: {
+            elements: {
+              point: {
+                pointStyle: false,
+              },
+            },
             legend: { display: false },
             scales: {
               xAxes: [
@@ -276,6 +281,11 @@ export const generateGraphs = async () => {
           ],
         },
         options: {
+          elements: {
+            point: {
+              pointStyle: false,
+            },
+          },
           legend: { display: false },
           scales: {
             xAxes: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -283,7 +283,9 @@ export const generateGraphs = async () => {
         options: {
           elements: {
             point: {
-              pointStyle: false,
+              radius: 0,
+              hitRadius: 0,
+              hoverRadius: 0,
             },
           },
           legend: { display: false },

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,9 @@ export const generateGraphs = async () => {
           options: {
             elements: {
               point: {
-                pointStyle: false,
+                radius: 0,
+                hoverRadius: 0,
+                hitRadius: 0,
               },
             },
             legend: { display: false },


### PR DESCRIPTION
The prerendered graphs on the dashboard currently contains a tiny circle for each datapoint. The circles are so small in the current design that they either are not visible or sort of look like a graphics glitch. This PR removes the circles so that the smooth line is the only shape in the graph.

Reference: https://www.chartjs.org/docs/latest/configuration/elements.html#point-configuration