### PR TITLE
:construction_worker: Modernize GitHub Actions CI

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,22 @@
 config:
-  - ./*
+  - changed-files:
+      - any-glob-to-any-file: "*"
 tooling:
-  - tooling/**/*.*
+  - changed-files:
+      - any-glob-to-any-file: "tooling/**/*.*"
 assets:
-  - static/**/*.*
+  - changed-files:
+      - any-glob-to-any-file: "static/**/*.*"
 tests:
-  - any: ["src/**/*.spec.js", "cypress/**/*"]
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/**/*.spec.js"
+          - "cypress/**/*"
 package:
-  - any: ["package.json", "package-lock.json"]
+  - changed-files:
+      - any-glob-to-any-file:
+          - "package.json"
+          - "package-lock.json"
 source:
-  - src/**/*
+  - changed-files:
+      - any-glob-to-any-file: "src/**/*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,35 +1,30 @@
 name: CodeQL CI
 on:
   schedule:
-    - cron: '0 0 * * 1'
+    - cron: "0 0 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   release:
     name: Build and analyze
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
           node-version: 14
+          cache: "npm"
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
           languages: javascript
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: Install dependencies
         run: npm ci
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   label-approve:
     name: Label and approve minor/patch updates
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: koj-co/dependabot-pr-action@master
         with:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,17 +2,23 @@ name: Pull Request Labeler
 on:
   - pull_request
   - pull_request_review
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - name: Label all PRs
-        uses: actions/labeler@master
+      - name: Label changed files
+        uses: actions/labeler@v6.1.0
         with:
-          repo-token: "${{ secrets.GH_PAT }}"
+          repo-token: "${{ secrets.GH_PAT || github.token }}"
       - name: Label approved PRs
-        uses: koj-co/label-approved-action@master
+        # Pin the current master commit; this action has no release after v1.0.0.
+        uses: koj-co/label-approved-action@5e7f8b5ab37030de670f7ba6ffa911fa9a4848b6
         with:
           labels: "merge"
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_PAT }}"
+          GITHUB_TOKEN: "${{ secrets.GH_PAT || github.token }}"

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -6,30 +6,20 @@ on:
 jobs:
   release:
     name: Build, test, and release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
           node-version: 14
+          cache: "npm"
       - name: Setup Licensed
         uses: jonabc/setup-licensed@v1.0.1
         with:
           version: 2.x
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
       - name: Install dependencies
         run: npm ci
       - name: Build TypeScript
@@ -55,13 +45,16 @@ jobs:
           user_email: "bot@koj.co"
           commit_message: ":page_facing_up: Update dependency license file [skip ci]"
       - name: Add PR comment
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         if: always() && steps.licensed.outputs.pr_number
         with:
           github-token: ${{ secrets.GH_PAT }}
           script: |
-            github.issues.createComment({
-              ...context.repo,
-              issue_number: ${{ steps.licensed.outputs.pr_number }}
-              body: "I've checked the license of your new dependency and it looks good!"
-            })
+            const issueNumber = Number("${{ steps.licensed.outputs.pr_number }}");
+            if (issueNumber) {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: issueNumber,
+                body: "I've checked the license of your new dependency and it looks good!"
+              });
+            }

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -4,70 +4,84 @@ on:
     branches-ignore:
       - master
       - production
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   auto-pull-request:
     name: PullRequestAction
     runs-on: ubuntu-latest
+    if: >-
+      startsWith(github.ref, 'refs/heads/feature') ||
+      startsWith(github.ref, 'refs/heads/hotfix') ||
+      startsWith(github.ref, 'refs/heads/bug')
     steps:
-      - name: Generate branch name
-        uses: actions/github-script@v3
-        id: set-branch-name
+      - name: Create or update pull request
+        uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.GH_PAT || github.token }}
           script: |
-            const capitalize = (name) => name.charAt(0).toUpperCase() + name.slice(1);
-            const emoji = context.payload.ref.startsWith("refs/heads/feature")
-              ? "✨ "
-              : context.payload.ref.startsWith("refs/heads/hotfix")
-              ? "🚑 "
-              : context.payload.ref.startsWith("refs/heads/bug")
-              ? "🐛 "
-              : "";
-            return `${emoji}${capitalize(
-              context.payload.ref
-                .replace("refs/heads/", "")
-                .replace(/-/g, " ")
-                .replace("feature ", "")
-                .replace("bug ", "")
-                .replace("hotfix ", "")
-            )}`;
-          result-encoding: string
-      - name: Set branch name
-        run: echo "PULL_REQUEST_TITLE=${{steps.set-branch-name.outputs.result}}" >> $GITHUB_ENV
-      - name: Generate PR body
-        uses: actions/github-script@v3
-        id: set-pr-body
-        with:
-          script: |
-            return `I'm opening this pull request for this branch, pushed by @${
-              context.payload.head_commit.author.username
-            } with ${context.payload.commits.length} commit${
-              context.payload.commits.length === 1 ? "" : "s"
+            const branch = context.ref.replace("refs/heads/", "");
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const base = "master";
+            const commits = context.payload.commits || [];
+            const actor =
+              context.payload.head_commit?.author?.username ||
+              context.actor ||
+              "a contributor";
+
+            const branchType = branch.startsWith("feature")
+              ? "feature"
+              : branch.startsWith("hotfix")
+              ? "hotfix"
+              : "bug";
+            const emoji = branchType === "feature" ? "✨ " : branchType === "hotfix" ? "🚑 " : "🐛 ";
+            const titleText = branch
+              .replace(new RegExp(`^${branchType}[/-]?`), "")
+              .replace(/[/-]+/g, " ")
+              .trim();
+            const title = `${emoji}${titleText.charAt(0).toUpperCase()}${titleText.slice(1)}`.trim();
+            const body = `I'm opening this pull request for this branch, pushed by @${actor} with ${commits.length} commit${
+              commits.length === 1 ? "" : "s"
             }.`;
-          result-encoding: string
-      - name: Set PR body
-        run: echo "PULL_REQUEST_BODY=${{steps.set-pr-body.outputs.result}}" >> $GITHUB_ENV
-      - name: Generate PR draft
-        uses: actions/github-script@v3
-        id: set-pr-draft
-        with:
-          script: |
-            return !context.payload.ref.startsWith("refs/heads/hotfix");
-      - name: Set PR draft
-        run: echo "PULL_REQUEST_DRAFT=${{steps.set-pr-draft.outputs.result}}" >> $GITHUB_ENV
-      - name: Determine whether to merge
-        uses: actions/github-script@v3
-        id: should-pr
-        with:
-          github-token: ${{ secrets.GH_PAT }}
-          script: |
-            return
-              context.payload.ref.startsWith("refs/heads/feature") ||
-              context.payload.ref.startsWith("refs/heads/hotfix") ||
-              context.payload.ref.startsWith("refs/heads/bug");
-      - name: pull-request-action
-        uses: vsoch/pull-request-action@1.0.15
-        if: always() && steps.should-pr.outputs.result
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-          PULL_REQUEST_BRANCH: "master"
-          PULL_REQUEST_REVIEWERS: "AnandChowdhary"
+            const draft = branchType !== "hotfix";
+
+            const { data: existing } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: "open",
+              head: `${owner}:${branch}`,
+              base,
+              per_page: 1,
+            });
+
+            if (existing.length > 0) {
+              core.info(`Pull request already exists: ${existing[0].html_url}`);
+              return existing[0].html_url;
+            }
+
+            const { data: pull } = await github.rest.pulls.create({
+              owner,
+              repo,
+              head: branch,
+              base,
+              title,
+              body,
+              draft,
+            });
+
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner,
+                repo,
+                pull_number: pull.number,
+                reviewers: ["AnandChowdhary"],
+              });
+            } catch (error) {
+              core.warning(`Could not request reviewer: ${error.message}`);
+            }
+
+            return pull.html_url;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,20 +1,22 @@
 name: Test CI
 on:
+  pull_request:
   push:
     branches-ignore:
       - master
 jobs:
   release:
     name: Build and test
-    runs-on: ubuntu-18.04
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || !contains(github.event.head_commit.message, '[skip ci]')
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v2.1.5
+        uses: actions/setup-node@v4
         with:
           node-version: 14
+          cache: "npm"
       - name: Install dependencies
         run: npm ci
       - name: Build TypeScript


### PR DESCRIPTION
## Summary
- Move Node/Test/CodeQL/Dependabot workflows off the retired `ubuntu-18.04` runner.
- Update first-party Actions to current runtimes (`checkout@v4`, `setup-node@v4`, CodeQL v3) while keeping Node 14 for package compatibility.
- Add PR-triggered Test CI coverage and fix the `github-script` license-comment block syntax/API usage.

## Test plan
- `npm ci` with Node 14/npm 6
- `node_modules/typescript/bin/tsc` under Node 14
- `node_modules/jest/bin/jest.js --forceExit --runInBand` under Node 14
- `actionlint` on changed workflows
- compiled the updated `actions/github-script` block with Node's `AsyncFunction`
