### PR TITLE
:construction_worker: Pin licensed CI action version

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -38,7 +38,7 @@ jobs:
           GIT_COMMITTER_EMAIL: "bot@koj.co"
       - name: Check dependency licenses
         id: licensed
-        uses: licensee/licensed-ci@v1
+        uses: licensee/licensed-ci@v1.12.1
         with:
           config_file: .github/licensed.yml
           github_token: ${{ secrets.GH_PAT || github.token }}


### PR DESCRIPTION
## Summary
- Pins `licensee/licensed-ci` to the existing `v1.12.1` tag.

## Test plan
- [x] `.github/workflows/node.yml` parses as YAML
- [x] `actionlint .github/workflows/node.yml`
- [x] Added-line security scan clean
- [x] Independent diff review passed

Follow-up to #244: post-merge main CI could not resolve the floating `licensee/licensed-ci@v1` ref.
