### PR TITLE
:construction_worker: Fix automerge token fallback

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -12,6 +12,14 @@ on:
   pull_request_review:
     types:
       - submitted
+
+permissions:
+  checks: read
+  contents: write
+  issues: write
+  pull-requests: write
+  statuses: read
+
 jobs:
   automerge:
     runs-on: ubuntu-latest
@@ -19,7 +27,7 @@ jobs:
       - name: Automerge
         uses: pascalgn/automerge-action@v0.15.5
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_PAT }}"
+          GITHUB_TOKEN: "${{ secrets.GH_PAT || github.token }}"
           MERGE_LABELS: "merge,!work in progress,!wip"
           MERGE_REMOVE_LABELS: "merge"
           MERGE_METHOD: "merge"
@@ -32,4 +40,4 @@ jobs:
         with:
           branches: "!master, !production, *"
         env:
-          GITHUB_TOKEN: "${{ secrets.GH_PAT }}"
+          GITHUB_TOKEN: "${{ secrets.GH_PAT || github.token }}"


### PR DESCRIPTION
## Summary
- Use the built-in `github.token` as a fallback when `GH_PAT` is unavailable in the Merge PRs workflow
- Declare the minimal workflow permissions the automerge/delete-branch actions need when using that fallback
- Keeps the existing `GH_PAT` behavior intact for repos/events where the PAT is available

## Test plan
- Parsed `.github/workflows/automerge.yml` with Python/YAML
- Ran `actionlint .github/workflows/automerge.yml`
- Ran `npm ci` under Node 14/npm 6 to match CI
- Ran `npm run build` under Node 14
- Ran Jest via Node 14: `node ./node_modules/jest/bin/jest.js --forceExit --runInBand`

Context: recent Dependabot PRs in this repo have green Build and test checks but failing `automerge` checks because `GITHUB_TOKEN` is empty when `secrets.GH_PAT` is unavailable.