### PR TITLE
:bug: Complete trusted publishing setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,16 @@ jobs:
           GIT_COMMITTER_NAME: "Koj Bot"
           GIT_COMMITTER_EMAIL: "bot@koj.co"
         run: |
-          NPM_EXE=$(npx npm@latest exec -- node -p "process.env.npm_execpath")
-          NPM_PACKAGE_DIR=$(dirname "$(dirname "$NPM_EXE")")
+          NPM_PACKAGE_JSON=$(node - <<'NODE'
+          const { createRequire } = require("module");
+          const requireFromSemanticReleaseNpm = createRequire(require.resolve("@semantic-release/npm"));
+          console.log(requireFromSemanticReleaseNpm.resolve("npm/package.json"));
+          NODE
+          )
+          NPM_PACKAGE_DIR=$(dirname "$NPM_PACKAGE_JSON")
           NPM_BIN_DIR=$(dirname "$NPM_PACKAGE_DIR")/.bin
-          export PATH="$NPM_BIN_DIR:$PATH"
-          npm --version
+          rm -f node_modules/.bin/npm node_modules/.bin/npx
+          ln -s "$NPM_BIN_DIR/npm" node_modules/.bin/npm
+          ln -s "$NPM_BIN_DIR/npx" node_modules/.bin/npx
+          ./node_modules/.bin/npm --version
           ./node_modules/.bin/semantic-release

--- a/.licenses/npm/safe-buffer-5.2.1.dep.yml
+++ b/.licenses/npm/safe-buffer-5.2.1.dep.yml
@@ -2,8 +2,33 @@
 name: safe-buffer
 version: 5.2.1
 type: npm
-summary: 
-homepage: 
-license: none
-licenses: []
+summary: Safer Node.js Buffer API
+homepage: https://github.com/feross/safe-buffer
+license: mit
+licenses:
+- sources: LICENSE
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) Feross Aboukhadijeh
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+- sources: README.md
+  text: MIT. Copyright (C) [Feross Aboukhadijeh](http://feross.org)
 notices: []

--- a/.licenses/npm/tr46.dep.yml
+++ b/.licenses/npm/tr46.dep.yml
@@ -2,8 +2,31 @@
 name: tr46
 version: 0.0.3
 type: npm
-summary: 
-homepage: 
-license: none
-licenses: []
+summary: An implementation of the Unicode TR46 spec
+homepage: https://github.com/Sebmaster/tr46.js#readme
+license: mit
+licenses:
+- sources: package.json#license and upstream LICENSE.md
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) Sebastian Mayr
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
 notices: []

--- a/.licenses/npm/webidl-conversions.dep.yml
+++ b/.licenses/npm/webidl-conversions.dep.yml
@@ -2,8 +2,22 @@
 name: webidl-conversions
 version: 3.0.1
 type: npm
-summary: 
-homepage: 
-license: none
-licenses: []
+summary: Implements the WebIDL algorithms for converting to and from JavaScript values
+homepage: https://github.com/jsdom/webidl-conversions#readme
+license: bsd-2-clause
+licenses:
+- sources: LICENSE.md
+  text: |
+    # The BSD 2-Clause License
+
+    Copyright (c) 2014, Domenic Denicola
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 notices: []

--- a/.licenses/npm/whatwg-url.dep.yml
+++ b/.licenses/npm/whatwg-url.dep.yml
@@ -2,8 +2,31 @@
 name: whatwg-url
 version: 5.0.0
 type: npm
-summary: 
-homepage: 
-license: none
-licenses: []
+summary: An implementation of the WHATWG URL Standard's URL API and parsing machinery
+homepage: https://github.com/jsdom/whatwg-url#readme
+license: mit
+licenses:
+- sources: LICENSE.txt
+  text: |
+    The MIT License (MIT)
+
+    Copyright (c) 2015–2016 Sebastian Mayr
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
 notices: []


### PR DESCRIPTION
## Summary

This follow-up finishes the Trusted Publishing migration by fixing the two failures seen after the previous PRs landed:

- ensure `@semantic-release/npm` resolves the npm 11 CLI it brings as a dependency, even when `execa` prefers the root `node_modules/.bin/npm` shim
- populate the missing Licensed cache entries for the newly introduced/upgraded npm transitive dependencies

## Why

The release workflow printed npm 11, but the publish subprocess still resolved the older root npm 7 shim because `@semantic-release/npm` uses a local-preferred command lookup. Replacing the root `node_modules/.bin/npm`/`npx` shims before running semantic-release makes the publish path use npm 11 consistently.

Licensed CI also failed because a few dependency cache records had `license: none` and empty license text after the dependency upgrade. These records now include the published package metadata/license text.

## Validation

- `actionlint .github/workflows/node.yml .github/workflows/release.yml`
- YAML parse for workflows, `.github/licensed.yml`, and touched `.licenses` records
- `git diff --check`
- added-line secret/injection scan
- Node 14 `npm ci && npm run build && npm run test`
- release block simulation: root npm before `7.24.2`, after `11.16.0`, child npm simulation `11.16.0`
- `semantic-release --dry-run --no-ci`
- independent review: passed with no security concerns or logic errors

## Notes

End-to-end npm publish still requires the npm package/org Trusted Publisher relationship to be configured for `upptime/graphs` + `release.yml` + `master`.
