### PR TITLE
:arrow_up: Bump actions/github-script from 7 to 9

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -37,7 +37,7 @@ jobs:
           user_email: "bot@koj.co"
           commit_message: ":page_facing_up: Update dependency license file [skip ci]"
       - name: Add PR comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         if: always() && steps.licensed.outputs.pr_number
         with:
           github-token: ${{ secrets.GH_PAT || github.token }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,7 @@ jobs:
       startsWith(github.ref, 'refs/heads/bug')
     steps:
       - name: Create or update pull request
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GH_PAT || github.token }}
           script: |


### PR DESCRIPTION
## Summary
- Bumps `actions/github-script` from v7 to v9 in the Node CI license-comment step and the PR generator workflow.
- Re-applies Dependabot PR #250 on top of current `master` so recent workflow updates (for example automerge v0.16.4) stay intact.

Supersedes #250.

## Test plan
- `git diff --check`
- Added-line security scan: clean
- YAML parse for changed workflows
- Compile both `actions/github-script` `script: |` blocks with Node AsyncFunction
- `actionlint` changed workflows via stdin
- `npx -y -p node@14 -p npm@6 npm ci`
- `npx -y -p node@14 -p npm@6 npm run build`
- `npx -y -p node@14 -p npm@6 npm test -- --runInBand`
