### PR TITLE
:arrow_up: Bump CodeQL action to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,10 +21,10 @@ jobs:
           node-version: 14
           cache: "npm"
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript
       - name: Install dependencies
         run: npm ci
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary
- Bumps the CodeQL workflow from `github/codeql-action` v3 to v4.
- Supersedes Dependabot PR #252 from the current default branch so the change does not depend on the stale Dependabot branch/automerge status.

## Validation
- `npm ci` / `npm test -- --runInBand` / `npm run build` with Node 14.21.3 and npm 6.14.18
- Parsed `.github/workflows/codeql.yml` with `js-yaml`
- Validated `.github/workflows/codeql.yml` with `actionlint`
- Added-line security scan: no findings
