### PR TITLE
:lock: Bump js-yaml to 4.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9284,9 +9284,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-      "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "requires": {
         "argparse": "^2.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "chartjs-node-canvas": "^3.0.8",
     "dayjs": "^1.9.6",
     "fs-extra": "^9.0.1",
-    "js-yaml": "^4.0.0"
+    "js-yaml": "^4.2.0"
   },
   "publishConfig": {
     "provenance": true,


### PR DESCRIPTION
## Summary
- Replaces Dependabot PR #262 with a Node 14/npm 6-compatible dependency update
- Bumps `js-yaml` from 4.0.0 to 4.2.0 in `package.json` and keeps `package-lock.json` at lockfileVersion 1
- Preserves the repo's legacy npm 6 install path, avoiding the v3 lockfile that made `npm ci` fail in CI

## Test plan
- `npm ci` with Node 14.21.3 / npm 6.14.18
- `npm run build`
- `npm test -- --runInBand`
- `git diff --check`
- Added-line security scan: no findings
- Independent Claude review: passed
- `npm pack --dry-run`

Replacement for #262.