### PR TITLE
:arrow_up: Bump actions/stale from 3 to 10

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GH_PAT }}
         stale-issue-message: "⚠️ This issue has not seen any activity in the past 2 months so I'm marking it as stale. I'll close it if it doesn't see any activity in the coming week."


### PR DESCRIPTION
## Summary
- Updates the repo-internal Stale Issues CI workflow from `actions/stale@v3` to `actions/stale@v10`
- Replaces stale Dependabot PR #251 from the current `master` branch so newer workflow maintenance is preserved

## Test Plan
- Parsed `.github/workflows/stale.yml` as YAML
- Ran `actionlint` on `.github/workflows/stale.yml` via stdin
- Ran `git diff --check`
- Ran added-line security scan
- Ran Node 14/npm 6 validation: `npm ci`, `npm run build`, `npm test -- --runInBand`, `npm pack --dry-run`

Supersedes #251.