### PR TITLE
:lipstick: Hide point markers in generated graphs

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,3 +1,87 @@
-test("hello world", () => {
-  expect(1).toBe(1);
+const mockRenderToBuffer = jest.fn();
+const mockListCommits = jest.fn();
+
+jest.mock("chartjs-node-canvas", () => ({
+  ChartJSNodeCanvas: jest.fn().mockImplementation(() => ({
+    renderToBuffer: mockRenderToBuffer,
+  })),
+}));
+
+jest.mock("@octokit/rest", () => ({
+  Octokit: jest.fn().mockImplementation(() => ({
+    repos: {
+      listCommits: mockListCommits,
+    },
+  })),
+}));
+
+jest.mock("@sindresorhus/slugify", () => jest.fn((value: string) => value.toLowerCase().replace(/\s+/g, "-")));
+
+jest.mock("fs-extra", () => ({
+  ensureDir: jest.fn().mockResolvedValue(undefined),
+  ensureFile: jest.fn().mockResolvedValue(undefined),
+  readFile: jest.fn().mockResolvedValue(""),
+  readJson: jest.fn(),
+  writeFile: jest.fn().mockResolvedValue(undefined),
+  writeJson: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("js-yaml", () => ({
+  load: jest.fn(),
+}));
+
+import { readJson } from "fs-extra";
+import { load } from "js-yaml";
+import { generateGraphs } from "./index";
+
+describe("generateGraphs", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (load as jest.Mock).mockReturnValue({
+      owner: "upptime",
+      repo: "status",
+      sites: [{ name: "Example Site" }],
+    });
+    (readJson as jest.Mock).mockResolvedValue([
+      {
+        name: "Example Site",
+        slug: "example-site",
+        status: "up",
+        uptime: "100",
+        uptimeDay: "100",
+        uptimeWeek: "100",
+        uptimeMonth: "100",
+        uptimeYear: "100",
+        time: 123,
+        timeDay: 123,
+        timeWeek: 123,
+        timeMonth: 123,
+        timeYear: 123,
+      },
+    ]);
+    mockListCommits.mockResolvedValue({
+      data: [
+        {
+          commit: {
+            author: { date: "2026-06-24T00:00:00Z" },
+            message: "🟩 Example Site is up (200 in 123 ms) [skip ci] [upptime]",
+          },
+        },
+      ],
+    });
+    mockRenderToBuffer.mockResolvedValue(Buffer.from("png"));
+  });
+
+  it("renders response-time graphs without point markers", async () => {
+    await generateGraphs();
+
+    expect(mockRenderToBuffer).toHaveBeenCalledTimes(5);
+    for (const [chartConfig] of mockRenderToBuffer.mock.calls) {
+      expect(chartConfig.options.elements.point).toEqual({
+        radius: 0,
+        hoverRadius: 0,
+        hitRadius: 0,
+      });
+    }
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,13 @@ export const generateGraphs = async () => {
             ],
           },
           options: {
+            elements: {
+              point: {
+                radius: 0,
+                hoverRadius: 0,
+                hitRadius: 0,
+              },
+            },
             legend: { display: false },
             scales: {
               xAxes: [
@@ -276,6 +283,13 @@ export const generateGraphs = async () => {
           ],
         },
         options: {
+          elements: {
+            point: {
+              radius: 0,
+              hoverRadius: 0,
+              hitRadius: 0,
+            },
+          },
           legend: { display: false },
           scales: {
             xAxes: [


### PR DESCRIPTION
## Summary
- Hides tiny point markers on generated response-time line charts by setting Chart.js v2 point radii to 0
- Replaces the placeholder Jest test with coverage that verifies every rendered graph config disables point markers
- Maintainer-owned replacement for #242; credit to @phieri for the original proposal and investigation

## Test plan
- `npm test -- --runInBand src/index.spec.ts`
- `npm run build`
- `npm test -- --runInBand`
- `npm pack --dry-run`

Supersedes #242.
