### PR TITLE
:bug: Support Unicode site names in graphs

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,5 +1,12 @@
 const mockRenderToBuffer = jest.fn();
 const mockListCommits = jest.fn();
+const mockSlugify = jest.fn((value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s:/.-]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+);
 
 jest.mock("chartjs-node-canvas", () => ({
   ChartJSNodeCanvas: jest.fn().mockImplementation(() => ({
@@ -15,7 +22,7 @@ jest.mock("@octokit/rest", () => ({
   })),
 }));
 
-jest.mock("@sindresorhus/slugify", () => jest.fn((value: string) => value.toLowerCase().replace(/\s+/g, "-")));
+jest.mock("@sindresorhus/slugify", () => mockSlugify);
 
 jest.mock("fs-extra", () => ({
   ensureDir: jest.fn().mockResolvedValue(undefined),
@@ -30,7 +37,7 @@ jest.mock("js-yaml", () => ({
   load: jest.fn(),
 }));
 
-import { readJson } from "fs-extra";
+import { ensureDir, readJson, writeJson } from "fs-extra";
 import { load } from "js-yaml";
 import { generateGraphs } from "./index";
 
@@ -83,5 +90,52 @@ describe("generateGraphs", () => {
         hitRadius: 0,
       });
     }
+  });
+
+  it("uses Unicode site names when slugify cannot produce an ASCII slug", async () => {
+    (load as jest.Mock).mockReturnValue({
+      owner: "upptime",
+      repo: "status",
+      sites: [{ name: "鸭鸭梨", url: "https://example.com" }],
+    });
+    (readJson as jest.Mock).mockResolvedValue([
+      {
+        name: "鸭鸭梨",
+        slug: "鸭鸭梨",
+        status: "up",
+        uptime: "99.9",
+        uptimeDay: "100",
+        uptimeWeek: "99.9",
+        uptimeMonth: "99.9",
+        uptimeYear: "99.9",
+        time: 234,
+        timeDay: 234,
+        timeWeek: 234,
+        timeMonth: 234,
+        timeYear: 234,
+      },
+    ]);
+    mockListCommits.mockResolvedValue({
+      data: [
+        {
+          commit: {
+            author: { date: "2026-06-24T00:00:00Z" },
+            message: "🟩 鸭鸭梨 is up (200 in 234 ms) [skip ci] [upptime]",
+          },
+        },
+      ],
+    });
+
+    await generateGraphs();
+
+    expect(mockSlugify).toHaveBeenCalledWith("鸭鸭梨");
+    expect(ensureDir).toHaveBeenCalledWith("api/鸭鸭梨");
+    expect(writeJson).toHaveBeenCalledWith(
+      "api/鸭鸭梨/uptime.json",
+      expect.objectContaining({ message: "99.9%" })
+    );
+    expect(mockListCommits).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "history/鸭鸭梨.yml" })
+    );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,32 @@ import { join } from "path";
 
 const canvasRenderService = new ChartJSNodeCanvas({ width: 600, height: 400 });
 
+type SiteConfig = { name: string; url: string; slug?: string };
+
+const sanitizeUnicodeSlug = (name: string): string =>
+  name
+    .normalize("NFKC")
+    .trim()
+    .replace(/[\\/]/g, "-")
+    .replace(/[<>:"|?*#%]/g, "-")
+    .replace(/[\u0000-\u001F\u007F]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[.-]+|[.-]+$/g, "");
+
+export const getSiteSlug = (site: SiteConfig): string => {
+  const explicitSlug = site.slug?.trim();
+  if (explicitSlug) return explicitSlug;
+
+  const asciiSlug = slugify(site.name);
+  if (asciiSlug) return asciiSlug;
+
+  const unicodeSlug = sanitizeUnicodeSlug(site.name);
+  if (unicodeSlug) return unicodeSlug;
+
+  return slugify(site.url) || "site";
+};
+
 /** Get commits for a history file */
 const getHistoryItems = async (
   octokit: Octokit,
@@ -62,7 +88,7 @@ const getResponseTimeColor = (responseTime: number) =>
 
 export const generateGraphs = async () => {
   const config = load(await readFile(join(".", ".upptimerc.yml"), "utf8")) as {
-    sites: { name: string; url: string; slug?: string }[];
+    sites: SiteConfig[];
     owner: string;
     repo: string;
     userAgent?: string;
@@ -80,7 +106,7 @@ export const generateGraphs = async () => {
   await ensureDir(join(".", "graphs"));
 
   for await (const site of config.sites) {
-    const slug = site.slug ? site.slug : slugify(site.name);
+    const slug = getSiteSlug(site);
     if (!slug) continue;
 
     let uptime = 0;


### PR DESCRIPTION
## Summary
- Adds shared slug resolution for graph generation: explicit `site.slug` → ASCII slugified name → sanitized Unicode site name → URL fallback.
- Preserves non-ASCII site names such as `鸭鸭梨` when ASCII slugification returns an empty value.
- Adds a regression test covering graph generation for a pure CJK site name.

Fixes upptime/upptime#933

## Test plan
- `PATH=/tmp/node-v14.21.3-linux-x64/bin:$PATH npm ci`
- `PATH=/tmp/node-v14.21.3-linux-x64/bin:$PATH npm test -- --runInBand src/index.spec.ts`
- `PATH=/tmp/node-v14.21.3-linux-x64/bin:$PATH npm run build`
- `PATH=/tmp/node-v14.21.3-linux-x64/bin:$PATH npm test`
- `PATH=/tmp/node-v14.21.3-linux-x64/bin:$PATH npm pack --dry-run`

## Notes
- This follows the Unicode slug fallback pattern already used by `upptime/uptime-monitor`.
- Local validation used Node 14 to match the legacy canvas/chartjs dependency stack.
