### PR TITLE
:lock: Update js-yaml to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9284,9 +9284,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "requires": {
         "argparse": "^2.0.1"
       }


### PR DESCRIPTION
## Summary
- update the direct runtime `js-yaml` lockfile entry from 4.2.0 to 4.3.1
- preserve the repository's Node 14/npm 6 `lockfileVersion: 1` contract
- replace unsafe Dependabot PR #282, whose v3 lockfile fails `npm ci` under the project runtime

## Security
- resolves direct runtime alerts GHSA-52cp-r559-cp3m and GHSA-5p4m-2wfm-xmqj
- leaves unrelated legacy/transitive alerts unchanged

## Test plan
- Node 14.21.3 / npm 6.14.18 `npm ci`
- `npm ls js-yaml --all`
- `npm run build`
- `npm test -- --runInBand` (2 suites, 4 tests)
- `npm pack --dry-run`
- npm audit comparison: high findings 430 → 428

Supersedes #282.
