### PR TITLE
:lock: Update brace-expansion to 1.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4659,9 +4659,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"


### PR DESCRIPTION
## Summary
- update the shared npm v1 lockfile entry for `brace-expansion` from 1.1.15 to 1.1.18
- preserve `lockfileVersion: 1` for the repository's Node 14/npm 6 CI contract
- replace Dependabot PR #284, whose npm v3 lockfile conversion fails `npm ci`

## Why
`brace-expansion` 1.1.18 is the first patched 1.x release for GHSA-rgw5-rvv9-x895 and also covers the earlier 1.x denial-of-service advisories. GitHub currently reports three high-severity runtime alerts against the shared 1.x resolution.

## Test plan
- Node 14.21.3 / npm 6.14.18 `npm ci`
- `npm run build`
- `npm test -- --runInBand` (2 suites, 4 tests)
- `npm pack --dry-run`
- npm audit baseline comparison (high findings 428 → 404; shared 1.1.15 findings removed)
- `git diff --check` and JSON parse

Supersedes #284.
