### PR TITLE
:package: Update dayjs to 1.11.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5273,9 +5273,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
-      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="
     },
     "debug": {
       "version": "4.1.1",


### PR DESCRIPTION
## Summary
- Updates the production `dayjs` resolution from 1.10.4 to 1.11.21.
- Preserves the repository’s npm v1 lockfile required by Node 14/npm 6 CI.
- Replaces the unsafe Dependabot approach in #286, which rewrites the whole lockfile to v3 and fails `npm ci`.

## Validation
- Node 14.21.3 / npm 6.14.18: `npm ci`
- `npm run build`
- `npm test -- --runInBand` (2 suites, 4 tests)
- `npm pack --dry-run`
- `git diff --check`

## Note
- `npm audit` still reports the existing legacy dependency backlog; this change only updates `dayjs` and introduces no new audit finding.