### PR TITLE
:package: Update chartjs-node-canvas to 3.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4825,9 +4825,9 @@
       }
     },
     "chartjs-node-canvas": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/chartjs-node-canvas/-/chartjs-node-canvas-3.1.0.tgz",
-      "integrity": "sha512-yL5hdb8dnhknBuUkz4CGL/rFSNudd8eKmKUsgVfrK5Fy8VswDI+DEfT4t2L/8H8sMRkzpAl42pEbERIghv3b0w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-node-canvas/-/chartjs-node-canvas-3.2.0.tgz",
+      "integrity": "sha512-MT0K28VG8BXwCdh5BdRXNw4nzJWKzcN3t/xgTr8zJ8M6uOXl7hRdtIW8rEUcylkLED8LGsnJmSkcnqlhPy841g==",
       "requires": {
         "canvas": "^2.6.1",
         "tslib": "^1.14.1"


### PR DESCRIPTION
## Summary
- Replaces Dependabot #292 with a minimal npm v1 lockfile update for `chartjs-node-canvas` 3.2.0.
- Preserves the Node 14/npm 6 lockfile format used by Test CI.

## Validation
- Node 14.21.3 / npm 6.14.18: `npm ci`
- `npm run build`
- `npm test -- --runInBand` (2 suites, 4 tests)
- `npm pack --dry-run`
- `git diff --check`

Supersedes #292, whose lockfileVersion 3 fails `npm ci` under the supported runtime.